### PR TITLE
Modify to install tensorflow-macos for M1/M2 Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,22 @@ import versioneer
 
 
 setup(
-    name='tensorpotential',
-    #version=versioneer.get_version(),
-    version='0.2.0+19.gfa5b8b0',
+    name="tensorpotential",
+    # version=versioneer.get_version(),
+    version="0.2.0+19.gfa5b8b0",
     cmdclass=versioneer.get_cmdclass(),
-    packages=['tensorpotential', 'tensorpotential.utils', 'tensorpotential.potentials', 'tensorpotential.functions'],
-    package_dir={'': 'src'},
-    url='',
-    license='',
-    author='Anton Bochkarev',
-    author_email='',
-    description='',
-    python_requires='<3.10',
-    install_requires=
-    [
-    'scipy',
-    'tensorflow<=2.9.1',
-    'numpy',
-    'pandas',
-    'ase'
-    ]
+    packages=[
+        "tensorpotential",
+        "tensorpotential.utils",
+        "tensorpotential.potentials",
+        "tensorpotential.functions",
+    ],
+    package_dir={"": "src"},
+    url="",
+    license="",
+    author="Anton Bochkarev",
+    author_email="",
+    description="",
+    python_requires="<3.10",
+    install_requires=["scipy", "tensorflow<=2.9.1", "numpy", "pandas", "ase"],
 )
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,20 @@
+import platform
+
 from setuptools import setup
 
 import versioneer
+
+install_requires = [
+    "scipy",
+    "numpy",
+    "pandas",
+    "ase",
+]
+if platform.system() == "Darwin" and platform.machine() == "arm64":
+    # M1/M2 Mac
+    install_requires.append("tensorflow-macos<=2.9.1")
+else:
+    install_requires.append("tensorflow<=2.9.1")
 
 
 setup(
@@ -21,5 +35,5 @@ setup(
     author_email="",
     description="",
     python_requires="<3.10",
-    install_requires=["scipy", "tensorflow<=2.9.1", "numpy", "pandas", "ase"],
+    install_requires=install_requires,
 )


### PR DESCRIPTION
Thank you so much developers for sharing the code, which helps me quite a lot for jumping into ML-potential researches!

# Short description

This modification allows us to install `tensorpotential` also in M1/M2 Mac.

# Long description

The original `tensorflow` (as of `2.12.0`) seems not available for M1/M2 Mac; we cannot find a wheel for M1/M2 Mac in PyPI (https://pypi.org/project/tensorflow/2.12.0/#files), and indeed I obtained the following error message;
```console
% pip install tensorflow
ERROR: Could not find a version that satisfies the requirement tensorflow (from versions: none)
ERROR: No matching distribution found for tensorflow
```
Apple, instead, offers their own optimized `tensorflow` in a different name, `tensorflow-macos` (see https://developer.apple.com/metal/tensorflow-plugin/). To use this, however, we need to specify `tensorflow-macos` instead of `tensorflow` in `install_requires`.

For a simple specification of a platform, we may be able to use [environment markers](https://peps.python.org/pep-0508/#environment-markers), but to specify M1/M2 Mac, it seems more straightforward to use the `platform` library.